### PR TITLE
Use crypto.randomBytes instead of Math.random;

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 
 var assert = require('assert')
+var crypto = require('crypto')
 
 var base62 = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 var base36 = 'abcdefghijklmnopqrstuvwxyz0123456789'
@@ -19,7 +20,10 @@ function create(chars) {
     len = len || 10
     assert(typeof len === 'number' && len >= 0, 'the length of the random string must be a number!')
     var salt = ''
-    for (var i = 0; i < len; i++) salt += chars[Math.floor(length * Math.random())]
+    for (var i = 0; i < len; i++) {
+      var rndVal = (crypto.randomBytes(1).readIntBE(0,1) + 128) / 256;
+      salt += chars[Math.floor(length * rndVal)]
+    }
     return salt
   }
 }


### PR DESCRIPTION
During the security scan, the AppSec platform has found a vulnerability in the library code and recommends to use cryptographic random instead of Math.ramdon. So there are changes according to these recommendations;